### PR TITLE
aways use posix paths on generated relative paths in html

### DIFF
--- a/livemark/helpers.py
+++ b/livemark/helpers.py
@@ -23,8 +23,12 @@ def read_asset(*paths):
         return file.read().strip()
 
 
-def get_relpath(path, current):
+def get_url_relpath(path, current):
     return posixpath.relpath(path, os.path.dirname(current))
+
+
+def get_relpath(path, current):
+    return os.path.relpath(path, os.path.dirname(current))
 
 
 def with_format(path, format):

--- a/livemark/helpers.py
+++ b/livemark/helpers.py
@@ -1,5 +1,6 @@
 import io
 import os
+import posixpath
 import sys
 import shutil
 import tempfile
@@ -23,7 +24,7 @@ def read_asset(*paths):
 
 
 def get_relpath(path, current):
-    return os.path.relpath(path, os.path.dirname(current))
+    return posixpath.relpath(path, os.path.dirname(current))
 
 
 def with_format(path, format):

--- a/livemark/plugins/blog/plugin.py
+++ b/livemark/plugins/blog/plugin.py
@@ -25,7 +25,7 @@ class BlogPlugin(Plugin):
     @property
     def relpath(self):
         path = f"{self.path}/index.html"
-        return helpers.get_relpath(path, self.document.path)
+        return helpers.get_url_relpath(path, self.document.path)
 
     @property
     def items(self):
@@ -35,7 +35,7 @@ class BlogPlugin(Plugin):
         index_path = "/".join([self.path, "index"])
         for document in self.document.project.documents:
             if document.path.startswith(self.path) and document.path != index_path:
-                relpath = helpers.get_relpath(document.path, self.document.path)
+                relpath = helpers.get_url_relpath(document.path, self.document.path)
                 items.append({"document": document, "relpath": relpath})
         return items
 

--- a/livemark/plugins/brand/plugin.py
+++ b/livemark/plugins/brand/plugin.py
@@ -16,7 +16,7 @@ class BrandPlugin(Plugin):
 
     @property
     def path(self):
-        return helpers.get_relpath(".", self.document.path)
+        return helpers.get_url_relpath(".", self.document.path)
 
     @property
     def text(self):

--- a/livemark/plugins/pages/plugin.py
+++ b/livemark/plugins/pages/plugin.py
@@ -42,7 +42,9 @@ class PagesPlugin(Plugin):
                 document = self.document.project.get_document(subitem["path"])
                 subitem.setdefault("name", document.get_plugin("site").name)
                 subitem["active"] = False
-                subitem["relpath"] = helpers.get_url_relpath(subitem["path"], self.current)
+                subitem["relpath"] = helpers.get_url_relpath(
+                    subitem["path"], self.current
+                )
                 if subitem["path"] == self.current:
                     item["active"] = True
                     subitem["active"] = True

--- a/livemark/plugins/pages/plugin.py
+++ b/livemark/plugins/pages/plugin.py
@@ -42,7 +42,7 @@ class PagesPlugin(Plugin):
                 document = self.document.project.get_document(subitem["path"])
                 subitem.setdefault("name", document.get_plugin("site").name)
                 subitem["active"] = False
-                subitem["relpath"] = helpers.get_relpath(subitem["path"], self.current)
+                subitem["relpath"] = helpers.get_url_relpath(subitem["path"], self.current)
                 if subitem["path"] == self.current:
                     item["active"] = True
                     subitem["active"] = True
@@ -51,7 +51,7 @@ class PagesPlugin(Plugin):
             if not subitems:
                 document = self.document.project.get_document(item["path"])
                 item.setdefault("name", document.get_plugin("site").name)
-                item["relpath"] = helpers.get_relpath(item["path"], self.current)
+                item["relpath"] = helpers.get_url_relpath(item["path"], self.current)
                 if item["path"] == self.current:
                     item["active"] = True
 

--- a/livemark/plugins/search/plugin.py
+++ b/livemark/plugins/search/plugin.py
@@ -17,7 +17,7 @@ class SearchPlugin(Plugin):
             item = {}
             item["name"] = document.get_plugin("site").name
             item["path"] = document.path
-            item["relpath"] = helpers.get_relpath(document.path, self.document.path)
+            item["relpath"] = helpers.get_url_relpath(document.path, self.document.path)
             item["text"] = document.content
             items.append(item)
         return items

--- a/livemark/plugins/signs/plugin.py
+++ b/livemark/plugins/signs/plugin.py
@@ -30,11 +30,11 @@ class SignsPlugin(Plugin):
                 if current_number:
                     if current_number > 1:
                         document = documents[current_number - 2]
-                        path = helpers.get_relpath(document.path, self.current)
+                        path = helpers.get_url_relpath(document.path, self.current)
                         prev = {"name": document.name, "path": path}
                     if current_number < len(documents):
                         document = documents[current_number]
-                        path = helpers.get_relpath(document.path, self.current)
+                        path = helpers.get_url_relpath(document.path, self.current)
                         next = {"name": document.name, "path": path}
                 return {"prev": prev, "next": next}
 

--- a/livemark/plugins/site/plugin.py
+++ b/livemark/plugins/site/plugin.py
@@ -45,7 +45,7 @@ class SitePlugin(Plugin):
     @property
     def favicon(self):
         if self.config.get("favicon"):
-            return helpers.get_relpath(self.config.get("favicon"), self.document.path)
+            return helpers.get_url_relpath(self.config.get("favicon"), self.document.path)
 
     @property
     def layout(self):


### PR DESCRIPTION
- fixes #205

---

With livemark is used in Windows, outside a POSIX compliant system the generated URLs inside the generated HTML will have Window back slashes (\folder\file instead of /folder/file). This happens because of how  `gel_relapath` is generating the path using os.path.join. os.path always follows the format of the current OS, this means, if you are in windows it is going to use back slashes. The problem happens that urls follow POSIX path, with this slash /. 

I don't know if there are other places that we need to change the paths to POSIX ones. If we just change everywhere that os.path is used, this will causes problems for windows user when livemark need to open a file somewhere. 
 